### PR TITLE
Re-create Token from outside the library

### DIFF
--- a/Source/Token.swift
+++ b/Source/Token.swift
@@ -74,7 +74,7 @@ public struct Token {
     /// The full response dictionary.
     public let dictionary: [String: Any]
     
-    internal init?(dictionary: [String: Any]) {
+    public init?(dictionary: [String: Any]) {
         guard dictionary["access_token"] as? String != nil else {
             return nil
         }


### PR DESCRIPTION
Enable re-creation of the Token when it was previously stored in custom token stores