### PR TITLE
Topic token dictionary

### DIFF
--- a/Source/Token.swift
+++ b/Source/Token.swift
@@ -78,11 +78,11 @@ public struct Token {
         guard dictionary["access_token"] as? String != nil else {
             return nil
         }
-        
+
 		var dictionary = dictionary
-		if dictionary["created_at"] == nil {
-			dictionary["created_at"] = Date.timeIntervalSinceReferenceDate
-		}
+        if dictionary["created_at"] == nil {
+            dictionary["created_at"] = Date.timeIntervalSinceReferenceDate
+        }
 
         self.dictionary = dictionary
     }

--- a/Source/Token.swift
+++ b/Source/Token.swift
@@ -78,12 +78,13 @@ public struct Token {
         guard dictionary["access_token"] as? String != nil else {
             return nil
         }
-
-		var dictionary = dictionary
+	
+	var dictionary = dictionary
+	
         if dictionary["created_at"] == nil {
             dictionary["created_at"] = Date.timeIntervalSinceReferenceDate
         }
-
+	
         self.dictionary = dictionary
     }
 }

--- a/Source/Token.swift
+++ b/Source/Token.swift
@@ -74,7 +74,7 @@ public struct Token {
     /// The full response dictionary.
     public let dictionary: [String: Any]
     
-    internal init?(dictionary: [String: Any]) {
+    public init?(dictionary: [String: Any]) {
         guard dictionary["access_token"] as? String != nil else {
             return nil
         }

--- a/Source/Token.swift
+++ b/Source/Token.swift
@@ -79,9 +79,11 @@ public struct Token {
             return nil
         }
         
-        var dictionary = dictionary
-        dictionary["created_at"] = Date.timeIntervalSinceReferenceDate
-        
+		var dictionary = dictionary
+		if dictionary["created_at"] == nil {
+			dictionary["created_at"] = Date.timeIntervalSinceReferenceDate
+		}
+
         self.dictionary = dictionary
     }
 }


### PR DESCRIPTION
When storing the existing Token, it already has proper created_at value. When restoring back using init(dictionary:) that original value should not be over-written.