### PR TITLE
Fix closing SafariViewController

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ github.additionalAuthRequestParams["allow_signup"] = "false"
 Handle the incoming requests in your `AppDelegate`:
 
 ```swift
-func application(app: UIApplication, openURL url: NSURL, options: [String : AnyObject]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
     github.handleURL(url, options: options)
 
     return true

--- a/Source/Provider.swift
+++ b/Source/Provider.swift
@@ -192,8 +192,10 @@ open class Provider: NSObject {
     }
     
     internal func handleURL(_ URL: Foundation.URL) {
-        safariVC?.dismiss(animated: true, completion: nil)
-        NotificationCenter.default.removeObserver(self, name: .UIApplicationDidBecomeActive)
+        defer {
+            safariVC?.dismiss(animated: true, completion: nil)
+            NotificationCenter.default.removeObserver(self, name: .UIApplicationDidBecomeActive)
+        }
         
         guard let completion = completion else { return }
         
@@ -342,20 +344,20 @@ private extension Provider {
 @available(iOS 9.0, *)
 extension Provider: SFSafariViewControllerDelegate {
     public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        safariVC?.dismiss(animated: true, completion: nil)
+        defer { safariVC?.dismiss(animated: true, completion: nil) }
         
         if let completion = completion {
-            DispatchQueue.main.async { completion(.failure(Error.cancel)) }
+            completion(.failure(Error.cancel))
         }
     }
 }
 
 extension Provider: WebViewControllerDelegate {
     func webViewControllerDidFinish(_ controller: WebViewController) {
-        safariVC?.dismiss(animated: true, completion: nil)
+        defer { safariVC?.dismiss(animated: true, completion: nil) }
         
         if let completion = completion {
-            DispatchQueue.main.async { completion(.failure(Error.cancel)) }
+            completion(.failure(Error.cancel))
         }
     }
 }


### PR DESCRIPTION
# Fixes
* Call `handleURL` method's callback closure before closing SafariViewController
  Because currently unstable. 

* Fix the usage handling incoming request in README